### PR TITLE
Remove fix for attempting to pass bash variables to CLI

### DIFF
--- a/crab.py
+++ b/crab.py
@@ -73,7 +73,7 @@ def main():
     # or if the command asks for one, or if explicitly specified.
     if (
         command[0] == "web"
-        or "PORT" in " ".join(command)
+        or "$PORT" in " ".join(command)
         or "CRAB_PROVIDE_PORT" in os.environ
     ):
         # provide a port in the environment and command line


### PR DESCRIPTION
`crab echo $PORT` would yield `crab echo ` if not set. This can be special cased to also replace `PORT` with the port number, but this causes issues with replacing parts of words (i.e. 'REPORT'). We can remove this, as it's possible to wrap the variable in single quotes to achieve the desired outcome (`crab echo '$PORT').