### PR TITLE
Fix router

### DIFF
--- a/router.py
+++ b/router.py
@@ -45,7 +45,7 @@ def proxy(path):
     return Response(
         response=downstream_response.content,
         status=downstream_response.status_code,
-        headers=downstream_response.headers.items(),
+        headers=downstream_response.raw.headers.items(),
     )
 
 


### PR DESCRIPTION
The router is not working properly on POST requests. This was being caused by three separate problems, all of which are fixed in this PR.

1. `request.data` in Flask is an already-parsed representation of the data (ie form-encoded stuff will be parsed!). So we have to use the confusingly-name `request.get_data()` to get the raw version.
2. Requests itself was following redirects, rather than propagating them to the browser.
3. a requests `Response` object's `.headers` attribute doesn't handle the case where there are multiple headers with the same name, as happens with `set-cookie` headers. It mangles them by joining them with commas. Instead, using `response.raw.headers` gives the underlying `urllib3` headers object, which does handle them correctly.