### PR TITLE
Use raw response data to fix encoding issues

### DIFF
--- a/router.py
+++ b/router.py
@@ -41,9 +41,10 @@ def proxy(path):
         headers=request.headers,
         data=request.get_data(),
         allow_redirects=False,
+        stream=True,
     )
     return Response(
-        response=downstream_response.content,
+        response=downstream_response.raw.data,
         status=downstream_response.status_code,
         headers=downstream_response.raw.headers.items(),
     )


### PR DESCRIPTION
The router wasn't working properly with gzip-encoded responses because Requests was being clever again and trying to handle the decoding for us. At this point I wonder if it might be easier to just use urllib3 directly rather than bothering with Requests.