### PR TITLE
Change response code to 502 when no backend found

### DIFF
--- a/router.py
+++ b/router.py
@@ -29,7 +29,7 @@ def proxy(path):
     hostname = urlparse(request.base_url).hostname
     if hostname not in routes:
         app.logger.warn(f"No backend for {hostname}")
-        abort(404)
+        abort(502)
 
     path = request.full_path if request.args else request.path
     target_url = f"http://localhost:{routes[hostname]}{path}"


### PR DESCRIPTION
It can sometimes be a bit confusing when a web process dies and you manually visit a URL as the 404 page sort of suggests you might have typed the URL wrong but really it's because the app has died.