### PR TITLE
Allow user to force crab to start a process on a given port

### DIFF
--- a/crab/cli.py
+++ b/crab/cli.py
@@ -67,8 +67,7 @@ def main():
         or "CRAB_PROVIDE_PORT" in os.environ
     ):
         # provide a port in the environment and command line
-        port = os.environ.get("CRAB_PROVIDE_PORT", get_free_port())
-        env["PORT"] = port
+        port = env.setdefault("PORT", get_free_port())
         command = [item.replace("$PORT", port) for item in command]
 
     # off we go


### PR DESCRIPTION
This reuses the existing `$CRAB_PROVIDE_PORT` var, as it's already in place, and sort of matches what's needed