### PR TITLE
More logical ordering of code

### DIFF
--- a/crab/cli.py
+++ b/crab/cli.py
@@ -28,20 +28,20 @@ def main(command=None):
 
     command = command or sys.argv[1:]
 
-    # do we need to inject a free port into the environment?
-    should_provide_port = False
-
-    # start with the base environment
-    env = dict(**os.environ)
-
     if not command or command[0] == "--version":
         print("crab v" + __version__)
         return
 
     # special case for the router
-    elif command[0] == "router":
+    if command[0] == "router":
         router.run()
         return
+
+    # do we need to inject a free port into the environment?
+    should_provide_port = False
+
+    # start with the base environment
+    env = dict(**os.environ)
 
     # add stuff from the envfile(s)
     envfile_paths = env.get("ENV_FILE", ".env").split(",")


### PR DESCRIPTION
This PR just improves readability a little. The code had got into a slightly weird order: the declaration of the environment and the `should_provide_port` boolean aren't needed for either of the special cases (`version` or `router`) but they were before them in the code.