### PR TITLE
Add a nicer message when a command doesn't exist

### DIFF
--- a/crab/cli.py
+++ b/crab/cli.py
@@ -4,6 +4,7 @@ import shlex
 import socket
 import sys
 from dotenv import dotenv_values
+import shutil
 
 
 def get_free_port():
@@ -76,6 +77,10 @@ def main(command=None):
         # provide a port in the environment and command line
         port = env.setdefault("PORT", get_free_port())
         command = [item.replace("$PORT", port) for item in command]
+
+    if shutil.which(command[0], path=env["PATH"]) is None:
+        print('Could not find "{}" in your procfile or $PATH.'.format(command[0]))
+        exit(1)
 
     # off we go
     os.execvpe(command[0], command, env)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,16 @@ class CLITestCase(TestCase):
         self.assertIn(__version__, cmd.stdout.decode())
         self.assertIn("crab", cmd.stdout.decode())
 
+    def test_missing_command(self):
+        cmd = subprocess.run(
+            ["crab", "this-command-shouldnt-exist"], stdout=subprocess.PIPE
+        )
+        self.assertEqual(cmd.returncode, 1)
+        self.assertIn(
+            'Could not find "this-command-shouldnt-exist" in your procfile or $PATH.',
+            cmd.stdout.decode(),
+        )
+
 
 class CLIExecutionTestCase(TestCase):
     def setUp(self):
@@ -47,17 +57,17 @@ class CLIExecutionTestCase(TestCase):
         del os.environ["PROC_FILE"]
 
     def test_port_provided_for_command_containing_port(self):
-        main(["somecommand", "$PORT"])
+        main(["echo", "$PORT"])
         provided_port = self.execvpe.call_args[0][2].get("PORT")
         self.assertTrue(provided_port and provided_port.isdigit())
 
     def test_port_provided_if_explicitly_requested(self):
         os.environ["CRAB_PROVIDE_PORT"] = "true"
-        main(["somecommand"])
+        main(["echo"])
         provided_port = self.execvpe.call_args[0][2].get("PORT")
         self.assertTrue(provided_port and provided_port.isdigit())
         del os.environ["CRAB_PROVIDE_PORT"]
 
     def test_port_not_provided_by_default(self):
-        main(["somecommand"])
+        main(["echo"])
         self.assertNotIn("PORT", self.execvpe.call_args[0][2])


### PR DESCRIPTION
Fixes #40 

Show a nice command when the requested command doesn't exist. Use `shutil.which` rather than catching in case we're catching too much. 