### PR TITLE
Remove the transfer-encoding header if present

### DIFF
--- a/crab/router.py
+++ b/crab/router.py
@@ -46,6 +46,11 @@ def proxy(path):
         allow_redirects=False,
         stream=True,
     )
+
+    # We need to remove the transfer-encoding header as this will
+    # no longer apply to the response we are about to send
+    downstream_response.raw.headers.pop("transfer-encoding", None)
+
     return Response(
         response=downstream_response.raw.data,
         status=downstream_response.status_code,


### PR DESCRIPTION
This was causing errors if the downstream server was sending chunked data. Inside the router we fully consume the downstream response and send a none-chunked response to the client. But the `transfer-encoding: chunked` header was still present, so the client was erroring:

`curl: (56) Illegal or missing hexadecimal sequence in chunked-encoding`